### PR TITLE
format&lint 正規表現修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "format": "prettier --write ./src/**/**/*.js",
-    "lint": "eslint --fix src/**/{*.js,*.jsx}"
+    "format": "prettier --write \"src/**/*.js\"",
+    "lint": "eslint --fix \"src/**/*.js\""
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
`win`, `unix`両方で(全ファイル)実行可能出来るよう修正