### PR TITLE
チケットモーダルのバグ修正

### DIFF
--- a/src/components/ticket/TicketConfirm.js
+++ b/src/components/ticket/TicketConfirm.js
@@ -4,11 +4,9 @@ import { createTicket } from '../../api';
 import TicketComplete from './TicketComplete';
 
 const TicketConfirm = (props) => {
-  const { values, hideConfirmation } = props;
+  const { ticket, values, hideConfirmation } = props;
 
   const value = {
-    date: values.date,
-    title: values.title,
     nameKana: values.nameKana,
     email: values.email,
     number: values.number,
@@ -47,12 +45,12 @@ const TicketConfirm = (props) => {
             <TicketDateAndTitleContainer>
               <TicketDateAndTitleTextField
                 type="text"
-                value={value.date}
+                value={ticket.date}
                 disabled
               />
               <TicketDateAndTitleTextField
                 type="text"
-                value={value.title}
+                value={ticket.title}
                 disabled
                 title
               />

--- a/src/pages/Live.js
+++ b/src/pages/Live.js
@@ -37,10 +37,9 @@ const Live = () => {
   const hideConfirmation = () => setIsConfirmationVisible(false);
 
   //submitボタンを押した時、入力内容確認画面を表示させる
-  const onSubmitData = () => {
+  const onSubmitData = handleSubmit(() => {
     setIsConfirmationVisible(true);
-    console.log(isConfirmationVisible);
-  };
+  });
 
   // TicketValue
   const [ticketValue, setTicketValue] = useState({
@@ -300,25 +299,17 @@ const Live = () => {
                 <TicketCautionText>
                   ※下記のライブのお申し込みでお間違いないかご確認ください。
                 </TicketCautionText>
-                <TicketFormContainer onSubmit={handleSubmit(onSubmitData)}>
+                <form onSubmit={onSubmitData}>
                   <TicketDateAndTitleContainer>
                     <TicketDateAndTitleTextField
                       type="text"
                       name="date"
                       value={ticketValue.date}
-                      readOnly
-                      {...register('date', {
-                        required: true,
-                      })}
                     />
                     <TicketDateAndTitleTextField
                       type="text"
                       name="title"
                       value={ticketValue.title}
-                      readOnly
-                      {...register('title', {
-                        required: true,
-                      })}
                       title
                     />
                   </TicketDateAndTitleContainer>
@@ -391,10 +382,11 @@ const Live = () => {
                   <TicketFormGroup className="right">
                     <TicketFormSubmitButton type="submit" value="確認する" />
                   </TicketFormGroup>
-                </TicketFormContainer>
+                </form>
               </TicketItemContainer>
             ) : (
               <TicketConfirm
+                ticket={ticketValue}
                 values={getValues()}
                 hideConfirmation={hideConfirmation}
               />
@@ -813,10 +805,6 @@ const TicketCautionText = styled.p`
   color: #f42626;
   margin: 0 24px 24px;
 `;
-
-// TicketFormContainer
-
-const TicketFormContainer = styled.form``;
 
 // ContactFormContainer
 

--- a/src/pages/Live.js
+++ b/src/pages/Live.js
@@ -304,11 +304,13 @@ const Live = () => {
                     <TicketDateAndTitleTextField
                       type="text"
                       name="date"
+                      readonly
                       value={ticketValue.date}
                     />
                     <TicketDateAndTitleTextField
                       type="text"
                       name="title"
+                      readonly
                       value={ticketValue.title}
                       title
                     />


### PR DESCRIPTION
## 概要

from slack
>フォームから確認画面に遷移するボタンをクリックするのに3回クリックしないといけないようになっている

原因はイベントの`日付`と`タイトル`も`react-hook-form`で管理していたために、確認ボタンを押したときに入力されていない判定になっていた。

## 変更点

- `required`の削除
- それに伴って`TicketConfirm`コンポーネントへのデータ受け渡し修正
